### PR TITLE
Handle Tasmanian Hansard search selector

### DIFF
--- a/.github/workflows/download_transcript.yml
+++ b/.github/workflows/download_transcript.yml
@@ -1,0 +1,33 @@
+name: Download transcript
+
+on:
+  workflow_dispatch:
+    inputs:
+      query:
+        description: 'Search text, e.g. "House of Assembly Tuesday 19 August 2025"'
+        required: true
+        default: 'House of Assembly Tuesday 19 August 2025'
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          playwright install chromium
+      - name: Download transcript
+        run: |
+          python download_transcript.py "${{ github.event.inputs.query }}"
+      - name: Commit downloaded transcript
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add transcripts/*.txt || echo 'No transcripts'
+          git commit -m "Add transcript for ${{ github.event.inputs.query }}" || echo 'No changes'
+          git push

--- a/download_transcript.py
+++ b/download_transcript.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Download Hansard transcripts from Tasmanian Parliament search site.
+
+This script uses Playwright to perform a search on the Hansard page and
+attempts to download the resulting transcript as a text file. The script is
+intended to run inside a GitHub Action where CORS restrictions are not an
+issue.
+
+Usage:
+    python download_transcript.py "House of Assembly Tuesday 19 August 2025"
+"""
+import os
+import re
+import sys
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeoutError
+
+ROOT = Path(__file__).parent.resolve()
+DOWNLOAD_DIR = ROOT / "transcripts"
+DOWNLOAD_DIR.mkdir(exist_ok=True)
+
+def sanitise_filename(name: str) -> str:
+    """Return a safe filename derived from the search query."""
+    safe = re.sub(r"[^a-zA-Z0-9._-]", "_", name)
+    return f"{safe}.txt"
+
+def download_transcript(query: str) -> None:
+    url = "https://search.parliament.tas.gov.au/adv/hahansard"
+    filename = sanitise_filename(query)
+    output_path = DOWNLOAD_DIR / filename
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(accept_downloads=True)
+        page = context.new_page()
+        page.goto(url)
+
+        # The search input may differ; attempt site-specific and generic selectors.
+        selectors = [
+            "#full-query",
+            "input[name='q[full-query]']",
+            "input[name='q-full-query']",
+            "input[name='q']",
+            "input[name='Query']",
+            "input[type='search']",
+            "#search",
+        ]
+        for selector in selectors:
+            try:
+                page.wait_for_selector(selector, timeout=10000)
+                page.fill(selector, query)
+                break
+            except PlaywrightTimeoutError:
+                continue
+        else:
+            raise RuntimeError("Search input not found; update selectors")
+
+        # Submit the search.
+        page.keyboard.press("Enter")
+
+        # Wait for results and attempt to find a TXT download link.
+        link = page.locator("a:has-text('TXT')").first
+        link.wait_for(timeout=15000)
+
+        with page.expect_download() as download_info:
+            link.click()
+        download = download_info.value
+        download.save_as(output_path)
+        print(f"Saved to {output_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: download_transcript.py <search query>")
+        sys.exit(1)
+    download_transcript(sys.argv[1])

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Hansard Downloader</title>
+</head>
+<body>
+<h1>Tasmanian Hansard Downloader</h1>
+<p>Enter a transcript title and trigger the GitHub Action to download it.</p>
+<form id="dispatch-form">
+  <label>GitHub token: <input id="token" type="password" required></label><br>
+  <label>Search query: <input id="query" size="60" value="House of Assembly Tuesday 19 August 2025" required></label><br>
+  <button type="submit">Fetch Transcript</button>
+</form>
+<pre id="result"></pre>
+<script>
+  const owner = 'YOUR_GITHUB_USERNAME';
+  const repo = 'Hans-Mon-V2';
+  const workflow = 'download_transcript.yml';
+  document.getElementById('dispatch-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const token = document.getElementById('token').value.trim();
+    const query = document.getElementById('query').value.trim();
+    const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflow}/dispatches`;
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ref: 'main', inputs: {query}})
+    });
+    const result = document.getElementById('result');
+    if (resp.ok) {
+      result.textContent = 'Workflow dispatched. Check the Actions tab on GitHub.';
+    } else {
+      result.textContent = `Error: ${resp.status} ${resp.statusText}`;
+    }
+  });
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+playwright


### PR DESCRIPTION
## Summary
- support Tasmanian Hansard search field by adding site-specific selectors
- wait for the input to appear before filling the query

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement playwright)*
- `python download_transcript.py "House of Assembly Tuesday 19 August 2025"` *(fails: No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68a7f6a14ed083328b5eeea3c6b6a818